### PR TITLE
Allow signing and verification with symmetric keys of arbitrary length

### DIFF
--- a/BappDescription.html
+++ b/BappDescription.html
@@ -1,0 +1,5 @@
+<p>JWT Editor is a Burp Suite extension and standalone application for editing, signing, verifying, encrypting and decrypting JSON Web Tokens (JWTs).</p>
+
+<p>When used within Burp Suite, it provides automatic detection and in-line editing of JWTs within HTTP requests/responses, signing and encrypting of tokens and automation of several well-known attacks against JWT implementations.</p>
+
+<p>For more information on usage of this extension, check out the <a href="https://github.com/PortSwigger/jwt-editor">README on GitHub</a></p>

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -3,10 +3,10 @@ ExtensionType: 1
 Name: JWT Editor
 RepoName: jwt-editor
 ScreenVersion: 1.0
-SerialVersion: 1
+SerialVersion: 2
 MinPlatformVersion: 0
 ProOnly: False
-Author: Blackberry
+Author: Fraser Winterborn, BlackBerry Security Research Group
 ShortDescription: Edit, sign, verify, encrypt and decrypt JSON Web Tokens (JWTs).
 EntryPoint: target/jwt-editor-1.0.0-jar-with-dependencies.jar
 BuildCommand: mvn package -DskipTests=true -Dmaven.javadoc.skip=true -B

--- a/BappManifest.bmf
+++ b/BappManifest.bmf
@@ -1,0 +1,13 @@
+Uuid: 26aaa5ded2f74beea19e2ed8345a93dd
+ExtensionType: 1
+Name: JWT Editor
+RepoName: jwt-editor
+ScreenVersion: 1.0
+SerialVersion: 1
+MinPlatformVersion: 0
+ProOnly: False
+Author: Blackberry
+ShortDescription: Edit, sign, verify, encrypt and decrypt JSON Web Tokens (JWTs).
+EntryPoint: target/jwt-editor-1.0.0-jar-with-dependencies.jar
+BuildCommand: mvn package -DskipTests=true -Dmaven.javadoc.skip=true -B
+SupportedProducts: Pro, Community

--- a/src/test/java/com/blackberry/jwteditor/SigningTests.java
+++ b/src/test/java/com/blackberry/jwteditor/SigningTests.java
@@ -18,17 +18,19 @@ limitations under the License.
 
 package com.blackberry.jwteditor;
 
-import com.blackberry.jwteditor.utils.CryptoUtils;
-import com.blackberry.jwteditor.utils.PEMUtils;
-
 import com.blackberry.jwteditor.model.jose.JWS;
 import com.blackberry.jwteditor.model.keys.JWKKey;
 import com.blackberry.jwteditor.model.keys.Key;
 import com.blackberry.jwteditor.model.keys.PasswordKey;
+import com.blackberry.jwteditor.utils.CryptoUtils;
+import com.blackberry.jwteditor.utils.PEMUtils;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.jwk.*;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.OctetKeyPair;
+import com.nimbusds.jose.jwk.OctetSequenceKey;
+import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.OctetSequenceKeyGenerator;
 import com.nimbusds.jose.util.Base64URL;
 import org.junit.jupiter.api.Test;
@@ -115,17 +117,19 @@ public class SigningTests {
                 new OctetSequenceKeyGenerator(256).generate(),
                 new OctetSequenceKeyGenerator(384).generate(),
                 new OctetSequenceKeyGenerator(512).generate(),
+                new OctetSequenceKey.Builder("secret123".getBytes()).build(),
         };
 
         for(OctetSequenceKey octetSequenceKey: octetSequenceKeys){
             JWKKey key = new JWKKey(octetSequenceKey);
-            if(key.canSign()) {
-                for (JWSAlgorithm algorithm : key.getSigningAlgorithms()) {
-                    JWSHeader signingInfo = new JWSHeader.Builder(algorithm).build();
-                    JWS jws = CryptoUtils.sign(signingInfo.toBase64URL(), TEST_JWS.getEncodedPayload(), key, signingInfo);
-                    assertTrue(CryptoUtils.verify(jws, key, signingInfo));
-                    atLeastOne = true;
-                }
+            assertTrue(key.canSign()); //any key should be able to sign
+
+            for (JWSAlgorithm algorithm : key.getSigningAlgorithms()) {
+                JWSHeader signingInfo = new JWSHeader.Builder(algorithm).build();
+                JWS jws = CryptoUtils.sign(signingInfo.toBase64URL(), TEST_JWS.getEncodedPayload(), key, signingInfo);
+                //we should be able to sign and verify with any supported algorithm
+                assertTrue(CryptoUtils.verify(jws, key, signingInfo));
+                atLeastOne = true;
             }
         }
         assertTrue(atLeastOne);


### PR DESCRIPTION
For JWT hackers, It would be useful to sign and verify JWT tokens with simple symmetric keys, such as "secret123" for example. 

Sadly the current implementation does not allow any keys which are not 256, 384 or 512 bits length. This is mainly dictated by the underlying library (nimbus) used for JWT operations.

We can elegantly bypass this limitation by padding short keys with zeroes, as it produces the same HMAC value (https://stackoverflow.com/questions/51883048/should-right-padding-an-hmac-sha256-secret-key-with-0-return-the-same-hash)

As a result, hackers are able to use any keys for testing their websites. It also helps to manually perform key confusion attacks.